### PR TITLE
Fixed sample env.text to mirror execution instructions in readme

### DIFF
--- a/sample-env.txt
+++ b/sample-env.txt
@@ -1,1 +1,1 @@
-DATABASE_URL='postgres://USERNAME:PASSWORD@localhost:5432/DATABASENAME'  
+DATABASE_URL='postgres://USERNAME:PASSWORD@localhost:5432/sac_hmis_db'  


### PR DESCRIPTION
Making sample-env.txt mirror the execution instructions in readme